### PR TITLE
Fix spelling of 'Permission' in Console Menu

### DIFF
--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -197,7 +197,7 @@ export default function BasicLayout({
             <SubMenu key="setting" icon={<SettingOutlined />} title="Setting">
               {role === 'root' ? (
                 <Menu.Item key="permission">
-                  <Link to="/setting/permission">Premission</Link>
+                  <Link to="/setting/permission">Permission</Link>
                 </Menu.Item>
               ) : null}
               {role === 'root' ? (


### PR DESCRIPTION
Fix spelling of 'Permission' in Console Menu

## Description

Update spelling in Menu item.

## Related Issue
https://github.com/dragonflyoss/console/issues/41

## Motivation and Context

Fix spelling.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Code compiles correctly.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
