### PR TITLE
fix: remove missing resize event listener cleanup and fix copy button aria-label

### DIFF
--- a/src/components/clusters/index.tsx
+++ b/src/components/clusters/index.tsx
@@ -129,6 +129,10 @@ export default function Clusters() {
 
       setTotalPages(totalPage);
       setAllClusters(currentPageData);
+
+      return () => {
+        window.removeEventListener('resize', updatePageSize);
+      };
     } else if (cluster === null || cluster) {
       setTotalPages(1);
       setAllClusters([]);

--- a/src/components/clusters/schedulers/index.tsx
+++ b/src/components/clusters/schedulers/index.tsx
@@ -227,23 +227,22 @@ export default function ShowCluster() {
         }
       });
 
+      const updatePageSize = () => {
+        if (window.matchMedia('(max-width: 1440px)').matches) {
+          setPageSize(9);
+        } else if (window.matchMedia('(max-width: 1600px)').matches) {
+          setPageSize(9);
+        } else if (window.matchMedia('(max-width: 1920px)').matches) {
+          setPageSize(12);
+        } else if (window.matchMedia('(max-width: 2048px)').matches) {
+          setPageSize(12);
+        } else if (window.matchMedia('(max-width: 2560px)').matches) {
+          setPageSize(15);
+        }
+      };
+
       if (alignment === 'card') {
-        const updatePageSize = () => {
-          if (window.matchMedia('(max-width: 1440px)').matches) {
-            setPageSize(9);
-          } else if (window.matchMedia('(max-width: 1600px)').matches) {
-            setPageSize(9);
-          } else if (window.matchMedia('(max-width: 1920px)').matches) {
-            setPageSize(12);
-          } else if (window.matchMedia('(max-width: 2048px)').matches) {
-            setPageSize(12);
-          } else if (window.matchMedia('(max-width: 2560px)').matches) {
-            setPageSize(15);
-          }
-        };
-
         updatePageSize();
-
         window.addEventListener('resize', updatePageSize);
       }
 
@@ -277,6 +276,10 @@ export default function ShowCluster() {
 
       setSchedulerTotalPages(totalPage);
       setAllSchedlers(currentPageData);
+
+      return () => {
+        window.removeEventListener('resize', updatePageSize);
+      };
     } else {
       setSchedulerTotalPages(1);
       setAllSchedlers([]);

--- a/src/components/clusters/seed-peers/index.tsx
+++ b/src/components/clusters/seed-peers/index.tsx
@@ -211,23 +211,22 @@ export default function ShowCluster() {
         }
       });
 
+      const updatePageSize = () => {
+        if (window.matchMedia('(max-width: 1440px)').matches) {
+          setPageSize(9);
+        } else if (window.matchMedia('(max-width: 1600px)').matches) {
+          setPageSize(9);
+        } else if (window.matchMedia('(max-width: 1920px)').matches) {
+          setPageSize(12);
+        } else if (window.matchMedia('(max-width: 2048px)').matches) {
+          setPageSize(12);
+        } else if (window.matchMedia('(max-width: 2560px)').matches) {
+          setPageSize(15);
+        }
+      };
+
       if (alignment === 'card') {
-        const updatePageSize = () => {
-          if (window.matchMedia('(max-width: 1440px)').matches) {
-            setPageSize(9);
-          } else if (window.matchMedia('(max-width: 1600px)').matches) {
-            setPageSize(9);
-          } else if (window.matchMedia('(max-width: 1920px)').matches) {
-            setPageSize(12);
-          } else if (window.matchMedia('(max-width: 2048px)').matches) {
-            setPageSize(12);
-          } else if (window.matchMedia('(max-width: 2560px)').matches) {
-            setPageSize(15);
-          }
-        };
-
         updatePageSize();
-
         window.addEventListener('resize', updatePageSize);
       }
 
@@ -261,6 +260,10 @@ export default function ShowCluster() {
 
       setSeedPeerTotalPages(totalPage);
       setAllSeedPeers(currentPageData);
+
+      return () => {
+        window.removeEventListener('resize', updatePageSize);
+      };
     } else {
       setSeedPeerTotalPages(1);
       setAllSeedPeers([]);

--- a/src/components/developer/tokens/index.tsx
+++ b/src/components/developer/tokens/index.tsx
@@ -201,7 +201,7 @@ export default function PersonalAccessTokens() {
           </Typography>
           <IconButton
             id="copy-button"
-            aria-label="delete"
+            aria-label="copy"
             sx={{
               p: '0',
               width: '1.6rem',

--- a/src/components/resource/persistent-cache-task/cluster/index.tsx
+++ b/src/components/resource/persistent-cache-task/cluster/index.tsx
@@ -100,6 +100,10 @@ export default function PersistentCacheTask() {
 
       setTotalPages(totalPage);
       setAllClusters(currentPageData);
+
+      return () => {
+        window.removeEventListener('resize', updatePageSize);
+      };
     } else if (cluster === null || cluster) {
       setTotalPages(1);
       setAllClusters([]);

--- a/src/components/resource/persistent-cache-task/information/index.tsx
+++ b/src/components/resource/persistent-cache-task/information/index.tsx
@@ -169,6 +169,10 @@ export default function Information(props: InformationProps) {
       setTotalPages(totalPage);
       setAllPersistentCacheTasks(currentPageData);
       setTaskIsLoading(true);
+
+      return () => {
+        window.removeEventListener('resize', updatePageSize);
+      };
     } else if (persistentCacheTasksCount === null || persistentCacheTasksCount) {
       setTotalPages(1);
       setAllPersistentCacheTasks([]);


### PR DESCRIPTION
## Description

Two bugs fixed:

1. `window.addEventListener('resize', updatePageSize)` was called inside `useEffect` without a cleanup in 5 components. Every time deps changed (page, alignment, data), a new listener piled on top. On a busy session that's a real leak - stale handlers keep firing and updating state on unmounted components.

2. The copy-token `IconButton` in `developer/tokens` had `aria-label="delete"` - copy-paste error, screen readers called it "delete".

## Related Issue

No open issue found for these.

## Motivation and Context

Fix 1: added `return () => window.removeEventListener('resize', updatePageSize)` in each effect. For schedulers/seed-peers where `updatePageSize` was scoped inside `if (alignment === 'card')`, moved it one level up so it's reachable from the cleanup (calling `removeEventListener` on a never-registered listener is a safe no-op).

Fix 2: changed `aria-label="delete"` to `aria-label="copy"`.

## How to reproduce

Leak: open the clusters or schedulers page in card view, resize the window, then navigate away and back a few times. Each render cycle adds another resize handler with no cleanup.

Aria label: inspect the copy-token button with devtools or a screen reader - it was announced as "delete".

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.